### PR TITLE
Make some changes in the way context(s) are managed and used.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "test:debug": "react-scripts --inspect-brk=mriehle.com:3001 test --runInBand --no-cache",
+    "test:debug": "react-scripts --inspect-brk=127.0.0.1:3001 test --runInBand --no-cache",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,9 @@ import { useState, useEffect, useCallback } from 'react';
 
 import './App.scss';
 
-import BombayContext from './BombayContext';
+import BombayLoginContext from './Context/BombayLoginContext';
+import BombayModeContext from './Context/BombayModeContext';
+import BombayUtilityContext from './Context/BombayUtilityContext';
 
 import HeaderBar from './AppLayout/HeaderBar';
 import Navigation from './AppLayout/Navigation';
@@ -14,21 +16,17 @@ import Footer from './AppLayout/Footer';
 import { loginStatus } from './Network/Login';
 
 function App() {
-  const [appState, setAppState] = useState({
-    title: 'Bombay Band Management System',
-    loggedIn: false,
-    mode: 'artist',
-  });
+  const [loginState, setLoginState] = useState(false);
+  const [modeState, setModeState] = useState('artist');
 
   const checkLoginState = useCallback(async () => {
-    debugger;
     const result = await loginStatus();
-    const newState = {
-      ...appState,
-      loggedIn: result.loggedIn,
-    }
-    setAppState(newState);
-  }, [appState]);
+    setLoginState(result.loggedIn);
+  }, []);
+
+  const setMode = useCallback((newMode) => {
+    setModeState(newMode);
+  }, []);
 
   useEffect(() => {
     // ToDo: Make the interval configurable, don't check if logged out.
@@ -39,18 +37,27 @@ function App() {
     return () => {
       clearInterval(intervalHandle);
     };
-  }, [checkLoginState]);
+  });
+
+  const utilities = {
+    checkLoginState,
+    setMode,
+  }
 
   return (
     <div className="App">
-      <BombayContext.Provider value={appState}>
-        <HeaderBar />
-        <Navigation />
-        <Filters />
-        <Content checkLoginState={checkLoginState}/>
-        <Accessories />
-        <Footer />
-      </BombayContext.Provider>
+      <BombayLoginContext.Provider value={loginState}>
+        <BombayModeContext.Provider value={modeState}>
+          <BombayUtilityContext.Provider value={utilities}>
+            <HeaderBar />
+            <Navigation />
+            <Filters />
+            <Content />
+            <Accessories />
+            <Footer />
+          </BombayUtilityContext.Provider>
+        </BombayModeContext.Provider>
+      </BombayLoginContext.Provider>
     </div >
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { act, render } from '@testing-library/react';
 import { loginStatus } from './Network/Login';
 
-import BombayContext from './BombayContext';
+import BombayLoginContext from './Context/BombayLoginContext';
 
 let mockLoggedIn = false;
 
@@ -59,8 +59,8 @@ jest.mock('./AppLayout/Filters', () => {
 });
 
 function MockContextConsumer(props) {
-  const ctx = useContext(BombayContext);
-  const lgsText = ctx.loggedIn ? 'Logged In' : 'Logged Out';
+  const loggedIn = useContext(BombayLoginContext);
+  const lgsText = loggedIn ? 'Logged In' : 'Logged Out';
 
   return (
     <div>

--- a/src/AppLayout/Content.js
+++ b/src/AppLayout/Content.js
@@ -1,36 +1,15 @@
-import { useContext } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
-import Login from "../Login/Login";
-
-import Artist from "../Mode/Artist";
-
-import BombayContext from '../BombayContext';
+import ContentRoutes from './ContentRoutes';
 
 function Content(props) {
-    const bombayContext = useContext(BombayContext);
-
-    debugger;
-
-    if (bombayContext.loggedIn) {
-        return (
-            <div className="content">
-                <BrowserRouter baseName="/">
-                    <Routes>
-                        <Route path="/" element={<Artist />} />
-                        <Route path="/artist" element={<Artist />} />
-                    </Routes>
-                </BrowserRouter>
-            </div>
-        );
-    } else {
-        return (
-            <div className="content">
-                return (<Login checkLoginState={props.checkLoginState}/>);
-            </div>
-    
-        );
-    }
+    return (
+        <div className="content">
+            <BrowserRouter baseName="/">
+                <ContentRoutes />
+            </BrowserRouter>
+        </div>
+    );
 }
 
 export default Content;

--- a/src/AppLayout/ContentRoutes.js
+++ b/src/AppLayout/ContentRoutes.js
@@ -1,0 +1,35 @@
+import { useContext, useEffect } from 'react';
+import { Routes, Route, useNavigate } from 'react-router-dom';
+
+import Login from "../Login/Login";
+
+import Artist from "../Mode/Artist";
+
+import BombayLoginContext from '../Context/BombayLoginContext';
+import BombayModeContext from '../Context/BombayModeContext';
+
+function Content(props) {
+    const loggedIn = useContext(BombayLoginContext);
+    const mode = useContext(BombayModeContext);
+
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        navigate(`/${mode}`);
+    }, [mode, navigate]);
+
+    if (loggedIn) {
+        return (
+            <Routes>
+                <Route path="/" element={<Artist />} />
+                <Route path="/artist" element={<Artist />} />
+            </Routes>
+        );
+    } else {
+        return (
+        <Login />
+        );
+    }
+}
+
+export default Content;

--- a/src/AppLayout/HeaderBar.js
+++ b/src/AppLayout/HeaderBar.js
@@ -2,26 +2,26 @@ import { useState, useContext } from 'react';
 
 import './HeaderBar.scss';
 
-import BombayContext from '../BombayContext';
+import BombayLoginContext from '../Context/BombayLoginContext';
 
 // Dummy elements for testing
 function LoggedInState(props) {
-    return (<div className="logged-in"></div>);
+    return (<div className="logged-in">Logged In</div>);
 }
 
 function LoggedOutState(props) {
-    return (<div className="logged-out"></div>);
+    return (<div className="logged-out">Logged Out</div>);
 }
 
 function HeaderBar(props) {
-    const context = useContext(BombayContext);
-
+    const loggedIn = useContext(BombayLoginContext);
+    const title=props.title || "Bombay Band Management System";
 
     return (
         <div className="header-bar">
-            <div className="title">{context.title}</div>
+            <div className="title">{title}</div>
             <div className="login-status">
-                {context.loggedIn ? <LoggedInState /> : <LoggedOutState />}
+                {loggedIn ? <LoggedInState /> : <LoggedOutState />}
             </div>
         </div>
     );

--- a/src/AppLayout/HeaderBar.test.js
+++ b/src/AppLayout/HeaderBar.test.js
@@ -1,18 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import HeaderBar from './HeaderBar';
 
-import BombayContext from '../BombayContext';
+import BombayLoginContext from '../Context/BombayLoginContext';
 
 test('renders the HeaderBar with the title from context', () => {
-    const dummyContext = {
-        title: 'The Title',
-        loggedIn: false,
-        mode: 'login',
-    };
-
     const result = render(
-        <ContextChanger context={dummyContext}>
-            <HeaderBar />
+        <ContextChanger loginState={false} modeState="artist">
+            <HeaderBar title="The Title" />
         </ContextChanger>
     );
 
@@ -37,15 +31,9 @@ test('renders the HeaderBar with the title from context', () => {
 })
 
 test('changes the login status when the context changes', () => {
-    const dummyContext = {
-        title: 'The Title',
-        loggedIn: false,
-        mode: 'login',
-    };
-
     const result = render(
-        <ContextChanger context={dummyContext}>
-            <HeaderBar />
+        <ContextChanger loginState={false} modeState="artist">
+            <HeaderBar title="The Title"/>
         </ContextChanger>
     );
 

--- a/src/BombayContext.js
+++ b/src/BombayContext.js
@@ -1,9 +1,0 @@
-import { createContext } from 'react';
-
-const BombayContext = createContext({
-    title: 'Bombay Band Management System',
-    loggedIn: false,
-    mode: 'login',
-});
-
-export default BombayContext;

--- a/src/Context/BombayLoginContext.js
+++ b/src/Context/BombayLoginContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const BombayLoginContext = createContext(false);
+
+export default BombayLoginContext;

--- a/src/Context/BombayModeContext.js
+++ b/src/Context/BombayModeContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const BombayLoginContext = createContext('artist');
+
+export default BombayLoginContext;

--- a/src/Context/BombayUtilityContext.js
+++ b/src/Context/BombayUtilityContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const BombayUtilityContext = createContext({});
+
+export default BombayUtilityContext;

--- a/src/Login/Login.js
+++ b/src/Login/Login.js
@@ -1,17 +1,24 @@
 import { useEffect, useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import './Login.scss';
 
-import BombayContext from '../BombayContext';
+import BombayLoginContext from '../Context/BombayLoginContext';
+import BombayModeContext from '../Context/BombayModeContext';
+import BombayUtilityContext from '../Context/BombayUtilityContext';
 
 import { login } from "../Network/Login";
 
 function Login(props) {
+    const navigate = useNavigate();
+
     const [timerHandle, setTimerHandle] = useState(null);
     const [credentials, setCredentials] = useState({ username: '', password: '' });
 
-    const bombayContext = useContext(BombayContext);
-    
+    const loggedIn = useContext(BombayLoginContext);
+    const mode = useContext(BombayModeContext);
+    const { checkLoginState } = useContext(BombayUtilityContext);
+
     useEffect(() => {
         const loginButton = document.querySelector('.btn.login');
 
@@ -23,6 +30,12 @@ function Login(props) {
             }
         }
     }, [credentials]);
+
+    useEffect(() => {
+        if (loggedIn) {
+            navigate(`/${mode}`);
+        }
+    }, [loggedIn, mode, navigate]);
 
     function handleChange(event) {
         const target = event.currentTarget;
@@ -64,8 +77,7 @@ function Login(props) {
         }
 
         await login(credentials.username, credentials.password);
-        debugger;
-        props.checkLoginState();
+        checkLoginState();
     }
 
     function togglePassword(evt) {
@@ -83,30 +95,34 @@ function Login(props) {
         }
     }
 
-    return (
-        <div className="login-container">
-            <div className="login-form">
-                <h1 className="login-header">Please Log In</h1>
-                <div className="info">
-                    <div>
-                        <div className="label">Username</div>
-                        <div className="input"><input className="username" type="text" onChange={handleChange} /></div>
-                    </div>
-                    <div>
-                        <div className="label">Password</div>
-                        <div className="input">
-                            <input className="password" type="password" onChange={handleChange} />
-                            <div className="toggle btn" data-hidden="true" onClick={togglePassword}>Show</div>
+    if (loggedIn) {
+        return '';
+    } else {
+        return (
+            <div className="login-container">
+                <div className="login-form">
+                    <h1 className="login-header">Please Log In</h1>
+                    <div className="info">
+                        <div>
+                            <div className="label">Username</div>
+                            <div className="input"><input className="username" type="text" onChange={handleChange} /></div>
+                        </div>
+                        <div>
+                            <div className="label">Password</div>
+                            <div className="input">
+                                <input className="password" type="password" onChange={handleChange} />
+                                <div className="toggle btn" data-hidden="true" onClick={togglePassword}>Show</div>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div className="controls">
-                    <div className="clear btn" onClick={clearAllFields}>Clear All Fields</div>
-                    <div className="login btn disabled" onClick={doLogin}>Login</div>
+                    <div className="controls">
+                        <div className="clear btn" onClick={clearAllFields}>Clear All Fields</div>
+                        <div className="login btn disabled" onClick={doLogin}>Login</div>
+                    </div>
                 </div>
             </div>
-        </div>
-    );
+        );
+    }
 }
 
 export default Login;

--- a/src/Network/Network.js
+++ b/src/Network/Network.js
@@ -84,7 +84,6 @@ export function getFromPath(path, query = {}) {
     xhr.open('GET', requestUrl);
     xhr.withCredentials = true;
     xhr.onload = function() {
-      debugger;
       if (xhr.status === 200) {
         resolve(xhr.response);
       } else {
@@ -104,7 +103,6 @@ export function postToPath(path, body = {}, query = {}) {
     xhr.withCredentials = true;
     xhr.setRequestHeader('content-type', 'application/json');
     xhr.onload = function() {
-      debugger;
       if (xhr.status === 200) {
         resolve(xhr.response);
       } else {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -6,27 +6,34 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
 import { useState } from 'react';
-import BombayContext from './BombayContext';
+import BombayLoginContext from './Context/BombayLoginContext';
+import BombayModeContext from './Context/BombayModeContext';
 
 // Use this to turn the crank on context changes.
-globalThis.ContextChanger = function(props) {
-    const [currentSet, setCurrentSet] = useState(props.context);
+globalThis.ContextChanger = function (props) {
+    const [loginState, setLoginState] = useState(props.loginState);
+    const [modeState, setModeState] = useState(props.modeState);
 
     function toggleLogin() {
-        const newSet = { ...currentSet };
-        newSet.loggedIn = !newSet.loggedIn;
-        setCurrentSet(newSet);
+        setLoginState(!loginState);
+    }
+
+    function updateModeState(evt) {
+        setModeState(evt.currentTarget.value);
     }
 
     return (
-        <BombayContext.Provider value={currentSet}>
-            {props.children}
-            <button className="change-test-login" onClick={toggleLogin}>Change Login</button>
-        </BombayContext.Provider>
+        <BombayLoginContext.Provider value={loginState}>
+            <BombayModeContext.Provider value={modeState}>
+                {props.children}
+                <button className="change-test-login" onClick={toggleLogin}>Change Login</button>
+                <input className="change-test-mode" type='text' onChange={updateModeState} />
+            </BombayModeContext.Provider>
+        </BombayLoginContext.Provider>
     );
 }
 
-globalThis.toggleLogin = function() {
+globalThis.toggleLogin = function () {
     const changeButton = document.querySelector('.change-test-login');
     userEvent.click(changeButton);
 }


### PR DESCRIPTION
This is a fundamental change in the way I'm using the context API for this.  Instead of an object for a single context, use multiple contexts where each one manages one and only one state.

- BombayContext becomes BombayLoginContext.  It only manages the login state.

- Create a Context directory to keep all the contexts. Move the existing context into that directory and create the new ones there as well.

- Add the BombayModeContext to manage the mode state.

- Add a BombayUtilityContext to allow easy access to setter functions required to change state.