### PR TITLE
Implement login expiration.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,13 +14,14 @@ import Content from './AppLayout/Content';
 import Accessories from './AppLayout/Accessories';
 import Footer from './AppLayout/Footer';
 
-import { loginStatus } from './Network/Login';
 import { fetchBootstrap } from './Network/Bootstrap';
+import useLoginTracking from './Hooks/useLoginTracking';
 
 function App() {
   const [bootstrap, setBootstrap] = useState(null);
-  const [loginState, setLoginState] = useState(false);
   const [modeState, setModeState] = useState('songList');
+
+  const [loginState, setLoginState] = useLoginTracking();
 
   const callFetchBootstrap = useCallback(async () => {
     try {
@@ -32,37 +33,16 @@ function App() {
     }
   }, []);
 
-  const checkLoginState = useCallback(async () => {
-    if (!bootstrap) return;
-
-    const result = await loginStatus();
-    setLoginState(result);
-    return result;
-  }, [bootstrap]);
-
-  const setMode = useCallback((newMode) => {
-    setModeState(newMode);
-    return newMode;
-  }, []);
-
-  const getBootstrap = () => bootstrap;
-
   useEffect(() => {
     callFetchBootstrap();
   }, [callFetchBootstrap]);
 
-  useEffect(() => {
-    checkLoginState();
+  const getBootstrap = () => bootstrap;
 
-    // ToDo: Make the interval configurable, don't check if logged out.
-    const intervalHandle = setInterval(async () => {
-      checkLoginState();
-    }, 10 * 60 * 1000); // Ten minutes.
-
-    return () => {
-      clearInterval(intervalHandle);
-    };
-  }, [bootstrap, checkLoginState]);
+  const setMode = useCallback((newMode) => {
+    setModeState(newMode);
+    return newMode;
+  }, []);  
 
   const utilities = {
     setMode,

--- a/src/AppLayout/ContentRoutes.js
+++ b/src/AppLayout/ContentRoutes.js
@@ -8,15 +8,19 @@ import ArtistList from "../Mode/Artist/ArtistList";
 import SongList from "../Mode/Song/SongList";
 
 import BombayModeContext from '../Context/BombayModeContext';
+// import BombayUtilityContext from '../Context/BombayUtilityContext';
 
 function Content(props) {
     const mode = useContext(BombayModeContext);
+    // const { checkLoginState } = useContext(BombayUtilityContext);
 
     const navigate = useNavigate();
 
     useEffect(() => {
+        // If I eliminate the mode context, this check might not be necessary.
+        // checkLoginState();
         navigate(mode);
-    }, [mode, navigate]);
+    }, [mode, navigate, /*checkLoginState*/]);
 
     return (
         <>

--- a/src/Hooks/useLoginTracking.js
+++ b/src/Hooks/useLoginTracking.js
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { loginStatus, refreshToken } from '../Network/Login';
+
+function toMilliseconds(minutes) {
+    return minutes * 60 * 1000;
+}
+
+export function useLoginTracking() {
+    const [loginState, setLoginState] = useState(false);
+    const [activitySeen, setActivitySeen] = useState(true);
+
+    const activityCheckMinutes = 30;
+    const loginCheckMinutes = 10;
+
+    let activityHandle = useRef(false);
+
+    const checkLoginState = useCallback(async function() {
+        const result = await loginStatus(activityCheckMinutes);
+        setLoginState(result);
+        return result;
+    }, []);
+
+    const refreshState = useCallback(async function() {
+        if (!loginState) return false;
+
+        const result = await refreshToken();
+        setLoginState(result != null);
+        return (result != null);
+    }, [loginState]);
+
+    const checkActivity = useCallback(function(evt) {
+        // console.debug(`${new Date().toLocaleString()}: Check Activity (${evt}) (Activity: ${activitySeen}, loginState: ${loginState})`);
+
+        clearTimeout(activityHandle.current);
+
+        if (evt != null) setActivitySeen(true);
+
+        activityHandle.current = setTimeout(async () => {
+            // console.debug(`${new Date().toLocaleString()}: Clear Activity (Activity: ${activitySeen}, loginState: ${loginState})`);
+
+            setActivitySeen(false);
+        }, toMilliseconds(activityCheckMinutes));
+    }, []);
+
+    const setListeners = useCallback(() => {
+        document.addEventListener('keydown', checkActivity);
+        document.addEventListener('mousedown', checkActivity);
+        document.addEventListener('mousemove', checkActivity);
+    }, [checkActivity]);
+
+    const removeListeners = useCallback(() => {
+        document.removeEventListener('mousemove', checkActivity);
+        document.removeEventListener('mousedown', checkActivity);
+        document.removeEventListener('keydown', checkActivity);
+    }, [checkActivity]);
+
+    const checkLogin = useCallback(async function() {
+        // console.debug(`${new Date().toLocaleString()}: Check login (Activity: ${activitySeen}, loginState: ${loginState})`);
+
+        if (activitySeen) {
+            await refreshState();
+            return;
+        }
+    
+        return await checkLoginState();
+    }, [activitySeen, refreshState, checkLoginState]);
+    
+    useEffect(() => {
+        // console.debug(`${new Date().toLocaleString()}: Change (Activity: ${activitySeen}, loginState: ${loginState})`);
+        let intervalHandle = false;
+
+        if (loginState) {
+            intervalHandle = setInterval(checkLogin, toMilliseconds(loginCheckMinutes));
+            checkActivity();
+            setListeners();
+        }
+    
+        return () => {
+            removeListeners();
+            clearTimeout(activityHandle.current);
+            clearInterval(intervalHandle);
+        };
+    }, [activitySeen, loginState, activityHandle, checkActivity, checkLogin, removeListeners, setListeners]);
+
+    useEffect(() => {
+        checkLoginState();
+    }, [checkLoginState]);
+
+    return [loginState, setLoginState];
+}
+
+export default useLoginTracking;

--- a/src/Hooks/useLoginTracking.test.js
+++ b/src/Hooks/useLoginTracking.test.js
@@ -1,0 +1,174 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import * as NetworkLogin from '../Network/Login';
+jest.mock('../Network/Login');
+
+import jwt_decode from 'jwt-decode';
+jest.mock('jwt-decode');
+
+import useLoginTracking from './useLoginTracking';
+
+function TestApp(props) {
+    const [loginState, setLoginState] = useLoginTracking();
+
+    // console.log(`TestApp ${loginState}`);
+
+    if (loginState) {
+        return <div>Logged In</div>;
+    } else {
+        return (
+            <>
+                <div>Logged Out</div>;
+                <button onClick={() => setLoginState(true)}>LOGIN</button>
+            </>
+        );
+    }
+}
+
+jest.useFakeTimers();
+
+const testToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJGREM4MTEzOCIsInVzZXIiOnsiaWQiOjEsIm5hbWUiOiJhZG1pbiIsImFkbWluIjpmYWxzZX0sImlhdCI6MTY2NTk2NTA5OX0.2vz14X7Tm-oFlyOa7dcAF-5y5ympi_UlWyJNxO4xyS4';
+const decodedTestToken = {
+    sub: 'FDC81138',
+    user: { id: 1, name: 'admin', admin: false },
+    iat: 0,
+}
+
+const loginAdvanceSeconds = 10 * 60;
+const activityAdvanceSeconds = 30 * 60;
+
+async function renderAndCheck(checkResolve = true) {
+    const mockCheckLoginPromise = NetworkLogin._setupMockPromise();
+    const mockRefreshTokenPromise = NetworkLogin._setupMockPromise();
+    mockRefreshTokenPromise.resolve(null); // Refresh token shouldn't be called initially.
+
+    NetworkLogin.loginStatus = jest.fn(() => mockCheckLoginPromise.promise);
+    NetworkLogin.refreshToken = jest.fn(() => mockRefreshTokenPromise.promise);
+
+    const result = render(<TestApp />)
+
+    expect(NetworkLogin.loginStatus).toBeCalledTimes(1);
+    expect(NetworkLogin.refreshToken).not.toBeCalled();
+
+    await act(async () => {
+        mockCheckLoginPromise.resolve(checkResolve);
+    });
+    
+    expect(NetworkLogin.loginStatus).toBeCalledTimes(1);
+    expect(NetworkLogin.refreshToken).not.toBeCalled();
+
+    return result;
+}
+
+it('should render as logged out', async function () {
+    await renderAndCheck(false);
+
+    const testDiv = screen.getByText(/Logged/);
+    expect(testDiv).toBeInTheDocument();
+    expect(testDiv).toHaveTextContent('Logged Out');
+});    
+
+it('should render as logged in', async function () {
+    await renderAndCheck();
+
+    const testDiv = screen.getByText(/Logged/);
+    expect(testDiv).toBeInTheDocument();
+    expect(testDiv).toHaveTextContent('Logged In');
+});
+
+async function nextCheck(loginStatusCalls, refreshTokenCalls, resolveToken, resolveLogin, loggedInText, loginFirst = false) {
+    const mockCheckLoginPromise = NetworkLogin._setupMockPromise();
+    const mockRefreshTokenPromise = NetworkLogin._setupMockPromise();
+
+    NetworkLogin.loginStatus = jest.fn(() => mockCheckLoginPromise.promise);
+    NetworkLogin.refreshToken = jest.fn(() => mockRefreshTokenPromise.promise);
+
+    // Advance the time to check login and refresh the token
+    await act(async () => {
+        jest.advanceTimersByTime(loginAdvanceSeconds * 1000);
+    });
+
+    expect(NetworkLogin.loginStatus).toBeCalledTimes(loginStatusCalls);
+    expect(NetworkLogin.refreshToken).toBeCalledTimes(refreshTokenCalls);
+
+    if (loginFirst) {
+        await act(async () => {
+            mockCheckLoginPromise.resolve(resolveLogin);
+        });
+    }
+
+    await act(async () => {
+        decodedTestToken.iat = decodedTestToken.iat + activityAdvanceSeconds;
+        mockRefreshTokenPromise.resolve(resolveToken);
+    });
+
+    expect(NetworkLogin.loginStatus).toBeCalledTimes(loginStatusCalls);
+    expect(NetworkLogin.refreshToken).toBeCalledTimes(refreshTokenCalls);
+
+    if (!loginFirst) {
+        await act(async () => {
+            mockCheckLoginPromise.resolve(resolveLogin);
+        });
+    }
+
+    const testDiv = screen.queryByText(/Logged/);
+    expect(testDiv).toBeInTheDocument();
+    expect(testDiv).toHaveTextContent(loggedInText);
+}
+
+it('should logout if there is no activity', async function () {
+    await renderAndCheck();
+    
+    await nextCheck(0, 1, testToken, true, 'Logged In');
+    await nextCheck(0, 1, testToken, true, 'Logged In');
+    await nextCheck(0, 1, testToken, true, 'Logged In');
+
+    await act(async () => {
+        jest.advanceTimersByTime(100000);
+    });
+    // As soon as the server times out, we're logged out.
+    await nextCheck(1, 0, null, false, 'Logged Out');
+});
+
+it('should refresh the token if there is activity', async function () {
+    const result = await renderAndCheck();
+    
+    const testDiv = screen.queryByText(/Logged/);
+    expect(testDiv).toBeInTheDocument();
+    expect(testDiv).toHaveTextContent('Logged In');
+    
+    await nextCheck(0, 1, testToken, true, 'Logged In');
+    await nextCheck(0, 1, testToken, true, 'Logged In');
+    await nextCheck(0, 1, testToken, true, 'Logged In');
+
+    // Reset activity
+    await act(async () => {
+        fireEvent(result.container, new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    });
+
+    await nextCheck(0, 1, testToken, true, 'Logged In');
+    await nextCheck(0, 1, testToken, true, 'Logged In');
+    await nextCheck(0, 1, testToken, true, 'Logged In');
+
+    // No more activity - will log out when the server does
+    await nextCheck(1, 0, null, true, 'Logged In');
+    await nextCheck(1, 0, null, true, 'Logged In');
+    await nextCheck(1, 0, null, false, 'Logged Out', true);
+});
+
+it('should set login state to true', async function () {
+    await renderAndCheck(false);
+
+    let testDiv = screen.queryByText(/Logged/);
+    expect(testDiv).toBeInTheDocument();
+    expect(testDiv).toHaveTextContent('Logged Out');
+    
+    const button = screen.getByText('LOGIN');
+
+    await act(async () => {
+        button.click();
+    });
+
+    testDiv = screen.queryByText(/Logged/);
+    expect(testDiv).toHaveTextContent('Logged In');
+});

--- a/src/Mode/Artist/ArtistList.test.js
+++ b/src/Mode/Artist/ArtistList.test.js
@@ -9,6 +9,9 @@ jest.mock('../../Network/Network');
 import useIntersectionObserver, * as mockObserver from '../../Hooks/useIntersectionObserver';
 jest.mock('../../Hooks/useIntersectionObserver');
 
+import * as Login from '../../Network/Login';
+jest.mock('../../Network/Login');
+
 import BombayLoginContext from '../../Context/BombayLoginContext';
 import BombayModeContext from '../../Context/BombayModeContext';
 import BombayUtilityContext from '../../Context/BombayUtilityContext';
@@ -96,6 +99,12 @@ function getAreas(result) {
 }
 
 it('should render the list', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve } = Network._setupMocks();
     const result = render(<FakeContent>
         <ArtistList />
@@ -117,6 +126,12 @@ it('should render the list', async () => {
 });
 
 it('should render the next page', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve: resolve1 } = Network._setupMocks();
     const result = render(<FakeContent>
         <ArtistList />
@@ -145,6 +160,12 @@ it('should render the next page', async () => {
 });
 
 it('should stop when it runs out of data', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve } = Network._setupMocks();
     const result = render(<FakeContent>
         <ArtistList />
@@ -170,6 +191,12 @@ it('should stop when it runs out of data', async () => {
 });
 
 it('should add an artist', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const modalRoot = document.getElementById('modal-root');
 
     const { resolve } = Network._setupMocks();

--- a/src/Mode/Song/SongList.test.js
+++ b/src/Mode/Song/SongList.test.js
@@ -9,6 +9,9 @@ jest.mock('../../Network/Network');
 import useIntersectionObserver, * as mockObserver from '../../Hooks/useIntersectionObserver';
 jest.mock('../../Hooks/useIntersectionObserver');
 
+import * as Login from '../../Network/Login';
+jest.mock('../../Network/Login');
+
 import BombayLoginContext from '../../Context/BombayLoginContext';
 import BombayModeContext from '../../Context/BombayModeContext';
 import BombayUtilityContext from '../../Context/BombayUtilityContext';
@@ -119,6 +122,12 @@ function getAreas(result) {
 }
 
 it('should render the list', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve } = Network._setupMocks();
     const result = render(<FakeContent>
         <SongList />
@@ -140,6 +149,12 @@ it('should render the list', async () => {
 });
 
 it('should render the next page', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve: resolve1 } = Network._setupMocks();
     const result = render(<FakeContent>
         <SongList />
@@ -168,6 +183,12 @@ it('should render the next page', async () => {
 });
 
 it('should stop when it runs out of data', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve } = Network._setupMocks();
     const result = render(<FakeContent>
         <SongList />
@@ -193,6 +214,12 @@ it('should stop when it runs out of data', async () => {
 });
 
 it('should add a song', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const modalRoot = document.getElementById('modal-root');
 
     const { resolve } = Network._setupMocks();

--- a/src/Model/CollectionBase.test.js
+++ b/src/Model/CollectionBase.test.js
@@ -13,6 +13,9 @@
 import * as Network from "../Network/Network";
 jest.mock('../Network/Network');
 
+import * as Login from '../Network/Login';
+jest.mock('../Network/Login');
+
 import ModelBase from './ModelBase';
 import CollectionBase from './CollectionBase';
 
@@ -27,6 +30,12 @@ afterEach(() => {
 });
 
 it('should fetch the first page', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve } = Network._setupMocks();
     
     const collection = new CollectionBase('/table');
@@ -38,6 +47,12 @@ it('should fetch the first page', async () => {
 });
 
 it('should instantiate with a set of models', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     // In this case, paging may not be possible.
     const collection = new CollectionBase('/table1', {
         models: [{
@@ -59,6 +74,12 @@ it('should instantiate with a set of models', async () => {
 });
 
 it('should fetch another page', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve: resolve1 } = Network._setupMocks();
 
     const collection = new CollectionBase('/table1');
@@ -78,6 +99,12 @@ it('should fetch another page', async () => {
 });
 
 it('should fetch the next page and not add duplicates', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     // The situation this is testing is actually slightly pathological and
     // not easy to handle.  This strategy really only works if the data
     // doesn't change often.
@@ -101,6 +128,12 @@ it('should fetch the next page and not add duplicates', async () => {
 });
 
 it('should handle a 404 at the end of the last page gracefully', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve: resolve1 } = Network._setupMocks();
     const collection = new CollectionBase('/table1');
 
@@ -126,6 +159,12 @@ it('should handle a 404 at the end of the last page gracefully', async () => {
 });
 
 it('should fetch the previous page', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const { resolve: resolve1 } = Network._setupMocks();
     const collection = new CollectionBase('/table1');
 
@@ -144,6 +183,12 @@ it('should fetch the previous page', async () => {
 });
 
 if('should fetch the previous page and not add duplicates', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     // The situation this is testing is actually slightly pathological and
     // not easy to handle.  This strategy really only works if the data
     // doesn't change often.

--- a/src/Network/Login.js
+++ b/src/Network/Login.js
@@ -1,5 +1,5 @@
 import jwt_decode from 'jwt-decode';
-import { prepareURLFromArgs, postToURLString } from './Network';
+import { prepareURLFromArgs, getFromURLString, postToURLString, putToURLString } from './Network';
 
 function setToken(token) {
   localStorage.setItem('jwttoken', token);
@@ -15,18 +15,44 @@ function deleteToken() {
   localStorage.removeItem('jwttoken');
 }
 
-export async function loginStatus()  {
+export async function loginStatus(expireMinutes = 30)  {
   const token = getToken();
 
   if (token) {
-    return true;
-    // To Do: This code should only execute if the token has expired.  I think.
-    // const requestURL = prepareURLFromArgs('login');
-    // const result = await getFromURLString(requestURL.toString());
-    // return result.loggedIn;
+    // Precalculate some stuff to make debugging a little easier.
+    const now = parseInt(Date.now() / 1000);
+    const tokenAge = now - token.iat;
+    const expireSeconds = expireMinutes * 60;
+
+    if (tokenAge <= expireSeconds) {
+      return true;
+    } else {
+      const requestURL = prepareURLFromArgs('login');
+      const result = await getFromURLString(requestURL.toString());
+
+      if (result.loggedIn) {
+        setToken(result.token);
+      } else {
+        deleteToken();
+      }
+
+      return result.loggedIn;
+    }
   }
 
   return false;
+};
+
+export async function refreshToken() {
+  try {
+    const requestUrl = prepareURLFromArgs('login');
+    const result = await putToURLString(requestUrl.toString(), {});
+    setToken(result);
+    return getToken();
+  } catch (err) {
+    deleteToken();
+    return null;
+  }
 };
 
 export async function login(username, password) {

--- a/src/Network/Login.test.js
+++ b/src/Network/Login.test.js
@@ -2,28 +2,67 @@ import * as Network from './Network';
 jest.mock('./Network');
 
 import jwt_decode from 'jwt-decode';
-import { loginStatus, login, logout } from './Login.js';
+jest.mock('jwt-decode');
+
+import { loginStatus, login, logout, refreshToken } from './Login.js';
 
 const testToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJGREM4MTEzOCIsInVzZXIiOnsiaWQiOjEsIm5hbWUiOiJhZG1pbiIsImFkbWluIjpmYWxzZX0sImlhdCI6MTY2NTk2NTA5OX0.2vz14X7Tm-oFlyOa7dcAF-5y5ympi_UlWyJNxO4xyS4';
+const decodedTestToken = {
+    sub: 'FDC81138',
+    user: { id: 1, name: 'admin', admin: false },
+    iat: 1665965099,
+}
 
-it('should get login status as true', async () => {
+it('should get login status as true without network call', async () => {
+    jwt_decode.mockReturnValue({...decodedTestToken, iat: parseInt(Date.now() / 1000)});
     localStorage.setItem('jwttoken', testToken);
 
-    const { resolve } = Network._setupMocks();
+    Network._setupMocks();
+
     const loginPromise = loginStatus();
     
     // To Do: This code should only execute if the token has expired.  I think.
-    // expect(Network.getFromURLString).toBeCalledTimes(1);
-    // expect(Network.getFromURLString).toBeCalledWith('http://localhost:2001/xyzzy/login');
+    expect(Network.getFromURLString).not.toBeCalled();
 
-    // resolve({ loggedIn: true });
     const result = await loginPromise;
     expect(result).toBeTruthy();
 
     localStorage.removeItem('jwttoken');
 });
 
-it('should get login status as false', async () => {
+it('should get login status as true with network call', async () => {
+    const nowIat = parseInt(Date.now() / 1000);
+    const oldIat = nowIat - (31 * 60); // Thirty one minutes;
+
+    const nowDecoded = {...decodedTestToken, sub: 'plover', iat: nowIat};
+    const oldDecoded = {...decodedTestToken, sub: 'xyzzy', iat: oldIat};
+
+    jwt_decode
+        .mockReturnValueOnce(oldDecoded)
+        .mockReturnValueOnce(nowDecoded);
+
+    localStorage.setItem('jwttoken', 'xyzzy');
+
+    const { resolve } = Network._setupMocks();
+    const loginPromise = loginStatus();
+
+    // To Do: This code should only execute if the token has expired.  I think.
+    expect(Network.getFromURLString).toBeCalledTimes(1);
+    expect(Network.getFromURLString).toBeCalledWith('http://localhost:2001/xyzzy/login');
+
+    resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+    const result = await loginPromise;
+    expect(result).toBeTruthy();
+    const storedToken = localStorage.getItem('jwttoken');
+    expect(storedToken).toEqual(testToken);
+
+    localStorage.removeItem('jwttoken');
+});
+
+it('should get login status as false (no token)', async () => {
     localStorage.removeItem('jwttoken');
 
     const {} = Network._setupMocks();
@@ -33,6 +72,56 @@ it('should get login status as false', async () => {
 
     const result = await loginPromise;
     expect(result).toBeFalsy();
+});
+
+it('should get login status as false (expired token)', async () => {
+    const oldIat = parseInt(Date.now() / 1000) - (31 * 60); // Thirty one minutes;
+    const oldDecoded = { ...decodedTestToken, sub: 'xyzzy', iat: oldIat };
+
+    jwt_decode.mockReturnValue(oldDecoded);
+
+    localStorage.setItem('jwttoken', testToken);
+
+    const { resolve } = Network._setupMocks();
+    const loginPromise = loginStatus();
+
+    // To Do: This code should only execute if the token has expired.  I think.
+    expect(Network.getFromURLString).toBeCalledTimes(1);
+    expect(Network.getFromURLString).toBeCalledWith('http://localhost:2001/xyzzy/login');
+
+    resolve({
+        loggedIn: false,
+        message: 'Session Expired',
+    });
+    const result = await loginPromise;
+    expect(result).toBeFalsy();
+    const storedToken = localStorage.getItem('jwttoken');
+    expect(storedToken).toBeNull();
+});
+
+it('should put to login and save token', async () => {
+    const localDecoded = {
+        sub: 'xyzzy',
+        user: { id: 2, name: 'plover', admin: false },
+        iat: 1665965230,
+    }
+    jwt_decode.mockReturnValue(localDecoded);
+    localStorage.setItem('jwttoken', testToken);
+
+    const { resolve } = Network._setupMocks();
+    const loginPromise = refreshToken();
+
+    // To Do: This code should only execute if the token has expired.  I think.
+    expect(Network.putToURLString).toBeCalledTimes(1);
+    expect(Network.putToURLString).toBeCalledWith('http://localhost:2001/xyzzy/login', {});
+
+    resolve('xyzzy');
+    const result = await loginPromise;
+    expect(result).toEqual(localDecoded);
+    const storedToken = localStorage.getItem('jwttoken');
+    expect(storedToken).toEqual('xyzzy');
+
+    localStorage.removeItem('jwttoken');
 });
 
 it('should post credentials to login and save token', async () => {

--- a/src/Network/Network.js
+++ b/src/Network/Network.js
@@ -54,7 +54,6 @@ function getStandardHeaders(includeContentType = true) {
 export function normalizeAndJoinPath(...pathParts) {
   const newPath = pathParts.reduce((memo, part) => {
     if (part === undefined) {
-      debugger;
       throw new Error(`Unable to normalize path with parts: "${pathParts.join(', ')}"`);
     }
 

--- a/src/Network/__mocks__/Login.js
+++ b/src/Network/__mocks__/Login.js
@@ -4,6 +4,10 @@ export async function loginStatus() {
     throw new Error('loginStatus has not been mocked properly');
 }
 
+export async function refreshToken() {
+    throw new Error('refreshToken has not been mocked properly');
+}
+
 export async function login(username, password) {
     throw new Error('login has not been mocked properly');
 }
@@ -28,12 +32,14 @@ export function _setupMockPromise() {
 
 export function _setupMocks() {
     _setupMockPromise();
-    this.loginStatus = jest.fn((urlString, query) => mockPromise);
-    this.login = jest.fn((urlString, body) => mockPromise);
-    this.logout = jest.fn((urlString, body) => mockPromise);
+    this.loginStatus = jest.fn(() => mockPromise);
+    this.refreshToken =jest.fn(() => mockPromise);
+    this.login = jest.fn((username, password) => mockPromise);
+    this.logout = jest.fn(() => mockPromise);
 
     return {
         resolve: mockResolve,
         reject: mockReject,
+        promise: mockPromise,
     };
 }

--- a/src/Widgets/PickerButton.test.js
+++ b/src/Widgets/PickerButton.test.js
@@ -3,6 +3,9 @@ import { act, render } from '@testing-library/react';
 import * as Network from '../Network/Network';
 import * as mockObserver from '../Hooks/useIntersectionObserver';
 
+import * as Login from '../Network/Login';
+jest.mock('../Network/Login');
+
 import ModelBase from '../model/ModelBase';
 import CollectionBase from '../model/CollectionBase';
 
@@ -33,6 +36,12 @@ afterEach(() => {
 })
 
 it('should show the button', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const onModelPicked = jest.fn();
 
     const { asFragment } = render(
@@ -52,6 +61,12 @@ it('should show the button', async () => {
 })
 
 it('should show the list on click', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const onModelPicked = jest.fn();
 
     const { resolve } = Network._setupMocks();
@@ -85,6 +100,12 @@ it('should show the list on click', async () => {
 })
 
 it('should call the callback and close the list when an item is clicked', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const onModelPicked = jest.fn();
 
     const { resolve } = Network._setupMocks();
@@ -126,6 +147,12 @@ it('should call the callback and close the list when an item is clicked', async 
 })
 
 it('should close the list without calling if the button is pushed again', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const onModelPicked = jest.fn();
 
     const { resolve } = Network._setupMocks();

--- a/src/Widgets/PickerList.test.js
+++ b/src/Widgets/PickerList.test.js
@@ -3,6 +3,9 @@ import { act, render } from '@testing-library/react';
 import * as Network from '../Network/Network';
 import  * as mockObserver from '../Hooks/useIntersectionObserver';
 
+import * as Login from '../Network/Login';
+jest.mock('../Network/Login');
+
 import ModelBase from '../model/ModelBase';
 import CollectionBase from '../model/CollectionBase';
 
@@ -33,8 +36,14 @@ afterEach(() => {
 })
 
 it('should show the list', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const pickModel = jest.fn();
-    
+
     const { resolve } = Network._setupMocks();
 
     const  { asFragment } = render(
@@ -63,6 +72,12 @@ it('should show the list', async () => {
 });
 
 it('should be an empty component', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const pickModel = jest.fn();
 
     const { container } = render(
@@ -77,6 +92,12 @@ it('should be an empty component', async () => {
 });
 
 it('should show the next page', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const pickModel = jest.fn();
 
     const { resolve } = Network._setupMocks();
@@ -121,6 +142,12 @@ it('should show the next page', async () => {
 });
 
 it('should call the callback when an item is clicked', async () => {
+    const loginPromise = Login._setupMocks();
+    loginPromise.resolve({
+        loggedIn: true,
+        token: testToken,
+    });
+
     const pickModel = jest.fn();
 
     const { resolve } = Network._setupMocks();


### PR DESCRIPTION
- Create the usLoginTracker module and use it in the app.
- ContentRoutes is no longer checking login status.  It shouldn't need to.
- Both the ArtistList and SongList had issues with managing the collection around logging in and logging out.  Fixed.

- Random lint changes.

Start on login modifications.

Works, but tests are not working.

Expire login is fixed.