### PR TITLE
Make Top and 404 visible when logged out.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import useLoginTracking from './Hooks/useLoginTracking';
 
 function App() {
   const [bootstrap, setBootstrap] = useState(null);
+  const [showLoginForm, setShowLoginForm] = useState(false);
 
   const [loginState, setLoginState] = useLoginTracking();
 
@@ -37,8 +38,24 @@ function App() {
 
   const getBootstrap = () => bootstrap;
 
+  const loginContext = {
+    loggedIn: loginState,
+    showLoginForm: showLoginForm,
+    setLoggedIn: newLoggedIn => {
+      if (newLoggedIn) {
+        setShowLoginForm(false);
+      }
+
+      setLoginState(newLoggedIn);
+    },
+
+    setShowLogin: newShow => {
+      if (loginState) return;
+      setShowLoginForm(newShow);
+    },
+  }
+
   const utilities = {
-    setLoginState,
     getBootstrap,
   }
 
@@ -51,7 +68,7 @@ function App() {
   return (
     <div className="App">
       <ConfigurationContext.Provider value={appConfig}>
-        <BombayLoginContext.Provider value={loginState}>
+        <BombayLoginContext.Provider value={loginContext}>
           <BombayUtilityContext.Provider value={utilities}>
             <HeaderBar />
             <Navigation />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -18,7 +18,7 @@ jest.mock('./AppLayout/HeaderBar', () => {
 
   return {
     __esModule: true,
-    ...originalModule, 
+    ...originalModule,
     default: () => {
       return (<div className="header-bar"></div>);
     },
@@ -52,7 +52,7 @@ jest.mock('./AppLayout/Filters', () => {
 });
 
 function MockContextConsumer(props) {
-  const loggedIn = useContext(BombayLoginContext);
+  const { loggedIn } = useContext(BombayLoginContext);
   const lgsText = loggedIn ? 'Logged In' : 'Logged Out';
 
   return (
@@ -95,7 +95,7 @@ test('Renders App Framework', async () => {
 
   const { resolve: bootstrapResolve } = NetworkBootstrap._setupMocks();
   bootstrapResolve({ key_signatures: ['A', 'B', 'C', 'D', 'E', 'F', 'G']});
-  
+
   const result = render(<App />);
 
   const index = result.container;

--- a/src/AppLayout/ContentRoutes.js
+++ b/src/AppLayout/ContentRoutes.js
@@ -1,4 +1,7 @@
+import { useContext } from 'react';
 import { Routes, Route } from 'react-router-dom';
+
+import BombayLoginContext from '../Context/BombayLoginContext';
 
 import Login from "../Login/Login";
 
@@ -7,20 +10,40 @@ import ArtistList from "../Mode/Artist/ArtistList";
 import SongList from "../Mode/Song/SongList";
 import PageNotFound from '../Mode/PageNotFound';
 
-function Content(props) {
-    return (
-        <>
-            <Routes>
+function ContentRoutes(props) {
+    const { loggedIn } = useContext(BombayLoginContext)
+
+    function loggedOutRoutes() {
+        return (
+            <>
+                <Route path="/" element={<Top />} />
+                <Route path="/artistList" element={<Top />} />
+                <Route path="/songList" element={<Top />} />
+            </>
+        );
+    }
+
+    function loggedInRoutes() {
+        return (
+            <>
                 <Route path="/" element={<Top />} />
                 <Route path="/artistList" element={<ArtistList />} />
                 <Route path="/songList" element={<SongList />} />
+            </>
+        );
+    }
+
+    return (
+        <>
+            <Routes>
+                {loggedIn ? loggedInRoutes() : loggedOutRoutes()}
 
                 {/* Handle page not found gracefully */}
                 <Route path="*" element={<PageNotFound />} />
             </Routes>
-            <Login />
+            {loggedIn ? null : <Login />}
         </>
     );
 }
 
-export default Content;
+export default ContentRoutes;

--- a/src/AppLayout/HeaderBar.test.js
+++ b/src/AppLayout/HeaderBar.test.js
@@ -1,8 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import HeaderBar from './HeaderBar';
 
-import BombayLoginContext from '../Context/BombayLoginContext';
-
 test('renders the HeaderBar with the title from context', () => {
     const result = render(
         <ContextChanger loginState={false} modeState="artist">
@@ -23,8 +21,8 @@ test('renders the HeaderBar with the title from context', () => {
     expect(loginStatusNode.tagName).toBe('DIV');
     expect(loginStatusNode.className).toBe('login-status');
 
-    expect(loginStatusNode.firstChild.tagName).toBe('DIV');
-    expect(loginStatusNode.firstChild.className).toBe('label');
+    expect(loginStatusNode.firstChild.tagName).toBe('BUTTON');
+    expect(loginStatusNode.firstChild.className).toBe('login btn');
     expect(loginStatusNode.firstChild.nextSibling).toBe(null);
 
     expect(loginStatusNode.nextSibling).toBe(null);
@@ -40,12 +38,12 @@ test('changes the login status when the context changes', () => {
     let headerTitleNode = screen.getByText('The Title');
     let loginStatusNode = headerTitleNode.nextSibling;
 
-    expect(loginStatusNode.firstChild.tagName).toBe('DIV');
-    expect(loginStatusNode.firstChild.className).toBe('label');
+    expect(loginStatusNode.firstChild.tagName).toBe('BUTTON');
+    expect(loginStatusNode.firstChild.className).toBe('login btn');
     expect(loginStatusNode.firstChild.nextSibling).toBe(null);
 
     toggleLogin();
-    
+
     headerTitleNode = screen.getByText('The Title');
     loginStatusNode = headerTitleNode.nextSibling;
 

--- a/src/Context/BombayLoginContext.js
+++ b/src/Context/BombayLoginContext.js
@@ -1,5 +1,10 @@
 import { createContext } from 'react';
 
-const BombayLoginContext = createContext(false);
+const BombayLoginContext = createContext({
+    loggedIn: false,
+    showLoginForm: false,
+    setLoggedIn: null,
+    setShowLogin: null,
+});
 
 export default BombayLoginContext;

--- a/src/Login/Login.js
+++ b/src/Login/Login.js
@@ -4,7 +4,6 @@ import { createPortal } from 'react-dom';
 import './Login.scss';
 
 import BombayLoginContext from '../Context/BombayLoginContext';
-import BombayUtilityContext from '../Context/BombayUtilityContext';
 
 import { loginStatus, login } from "../Network/Login";
 import LabeledInput from '../Widgets/LabeledInput';
@@ -16,8 +15,7 @@ function Login(props) {
     const [error, setError] = useState(null);
     const [submitDisabled, setSubmitDisabled] = useState(true);
 
-    const loggedIn = useContext(BombayLoginContext);
-    const { setLoginState } = useContext(BombayUtilityContext);
+    const { loggedIn, setLoggedIn, showLoginForm } = useContext(BombayLoginContext);
 
     function getCredentials() {
         // TODO: THere has to be a better way to do what these two lines are doing.
@@ -72,10 +70,11 @@ function Login(props) {
             });
 
         const loginOkay = await loginStatus();
-        setLoginState(loginOkay);
+        setLoggedIn(loginOkay);
     }
 
     if (loggedIn) return null;
+    if (!showLoginForm) return null;
 
     const modalRoot = document.getElementById('modal-root');
 

--- a/src/Login/Login.test.js
+++ b/src/Login/Login.test.js
@@ -16,30 +16,6 @@ import Login from './Login';
 
 jest.useFakeTimers();
 
-function FakeContent(props) {
-    const [loginState, setLoginState] = useState(false);
-    const [modeState, setModeState] = useState('artist');
-
-    const setMode = async newMode => {
-        setModeState(newMode);
-    }
-
-    const utilities = {
-        setMode,
-        setLoginState
-    }
-
-    return (
-        <BrowserRouter basename="/">
-            <BombayLoginContext.Provider value={loginState}>
-                <BombayUtilityContext.Provider value={utilities}>
-                    {props.children}
-                </BombayUtilityContext.Provider>
-            </BombayLoginContext.Provider>
-        </BrowserRouter>
-    );
-}
-
 beforeEach(() => {
     localStorage.removeItem('jwttoken');
 
@@ -54,9 +30,9 @@ afterEach(() => {
 });
 
 it('should render the login mode', async () => {
-    const { asFragment } = render(<FakeContent>
+    const { asFragment } = render(<ContextChanger loggedIn={false} showLoginForm={true}>
         <Login />
-    </FakeContent>);
+    </ContextChanger>);
 
     expect(asFragment).toMatchSnapshot();
 
@@ -64,11 +40,19 @@ it('should render the login mode', async () => {
     expect(modalRoot).toMatchSnapshot();
 });
 
+it('should not render the login mode', async () => {
+    render(<ContextChanger loggedIn={false} showLoginForm={false}>
+        <Login />
+    </ContextChanger>);
+
+    const modalRoot = document.getElementById('modal-root');
+    expect(modalRoot).toBeEmptyDOMElement();
+});
 
 it('should enable and disable the login button', async () => {
-    render(<FakeContent>
+    render(<ContextChanger loggedIn={false} showLoginForm={true}>
         <Login />
-    </FakeContent>);
+    </ContextChanger>);
 
     const modalRoot = document.getElementById('modal-root');
     const loginButton = modalRoot.querySelector('.login.btn');
@@ -84,9 +68,9 @@ it('should enable and disable the login button', async () => {
 it('should login successfully', async () => {
     const { resolve } = NetworkLogin._setupMocks();
 
-    const result = render(<FakeContent>
+    const result = render(<ContextChanger loggedIn={false} showLoginForm={true}>
         <Login />
-    </FakeContent>);
+    </ContextChanger>);
 
     const modalRoot = document.getElementById('modal-root');
     const loginButton = modalRoot.querySelector('.login.btn');
@@ -112,9 +96,9 @@ it('should login successfully', async () => {
 it('should show error on failed login', async () => {
     const { resolve } = NetworkLogin._setupMocks();
 
-    const result = render(<FakeContent>
+    const result = render(<ContextChanger loggedIn={false} showLoginForm={true}>
         <Login />
-    </FakeContent>);
+    </ContextChanger>);
 
     const modalRoot = document.getElementById('modal-root');
     const loginButton = modalRoot.querySelector('.login.btn');
@@ -140,9 +124,9 @@ it('should show error on failed login', async () => {
 it('should show error on call error', async () => {
     const { resolve } = NetworkLogin._setupMocks();
 
-    const result = render(<FakeContent>
+    const result = render(<ContextChanger loggedIn={false} showLoginForm={true}>
         <Login />
-    </FakeContent>);
+    </ContextChanger>);
 
     const modalRoot = document.getElementById('modal-root');
     const loginButton = modalRoot.querySelector('.login.btn');
@@ -168,9 +152,9 @@ it('should show error on call error', async () => {
 it('should clear the inputs and error on clear all fields', async () => {
     const { resolve } = NetworkLogin._setupMocks();
 
-    const result = render(<FakeContent>
+    const result = render(<ContextChanger loggedIn={false} showLoginForm={true}>
         <Login />
-    </FakeContent>);
+    </ContextChanger>);
 
     const modalRoot = document.getElementById('modal-root');
     const loginButton = modalRoot.querySelector('.login.btn');

--- a/src/Mode/Artist/ArtistList.js
+++ b/src/Mode/Artist/ArtistList.js
@@ -14,7 +14,7 @@ import FormModal from '../../Modal/FormModal';
 function ArtistList(props) {
     const topRef = createRef();
 
-    const loggedIn = useContext(BombayLoginContext);
+    const { loggedIn } = useContext(BombayLoginContext);
 
     const artistCollection = useRef(null);
     const observer = useIntersectionObserver(topRef, (entries, observer) => {

--- a/src/Mode/Artist/ArtistList.test.js
+++ b/src/Mode/Artist/ArtistList.test.js
@@ -20,7 +20,7 @@ import ArtistList from './ArtistList';
 jest.useFakeTimers();
 
 function FakeContent(props) {
-    const [loginState, setLoginState] = useState(true);
+    const [loginState, setLoginState] = useState({ loggedIn: true, showLoginForm: false });
     const [modeState, setModeState] = useState('artist');
 
     const checkLoginState = async () => {

--- a/src/Mode/Song/SongList.js
+++ b/src/Mode/Song/SongList.js
@@ -14,7 +14,7 @@ import FormModal from '../../Modal/FormModal';
 function SongList(props) {
     const topRef = createRef();
 
-    const loggedIn = useContext(BombayLoginContext);
+    const { loggedIn } = useContext(BombayLoginContext);
 
     const songCollection = useRef(null);
     const observer = useIntersectionObserver(topRef, (entries, observer) => {

--- a/src/Mode/Song/SongList.test.js
+++ b/src/Mode/Song/SongList.test.js
@@ -20,7 +20,7 @@ import SongList from './SongList';
 jest.useFakeTimers();
 
 function FakeContent(props) {
-    const [loginState, setLoginState] = useState(true);
+    const [loginState, setLoginState] = useState({ loggedIn: true, showLoginForm: false });
     const [modeState, setModeState] = useState('song');
 
     const checkLoginState = async () => {

--- a/src/Mode/Top.js
+++ b/src/Mode/Top.js
@@ -1,15 +1,32 @@
 
+import { useContext } from "react";
+
+import BombayLoginContext from "../Context/BombayLoginContext";
+import Button from "../Widgets/Button";
+
 import "./Top.scss";
 
 function Top(props) {
+    const { loggedIn, setShowLogin } = useContext(BombayLoginContext);
+
+    function showLogin() {
+        setShowLogin(true);
+    }
+
     return (
         <div className="app-home">
             <h1>Welcome to the Bombay Band Manager System</h1>
 
-            <ul>
-                <li><a href="artistList">Artist List</a></li>
-                <li><a href="songList">Song List</a></li>
-            </ul>
+            {loggedIn ?
+                <ul>
+                    <li><a href="artistList">Artist List</a></li>
+                    <li><a href="songList">Song List</a></li>
+                </ul> :
+                <div>
+                    <h2>Please Login to continue</h2>
+                    <Button className="login btn" onClick={showLogin} disabled={false} label="Login" />
+                </div>
+            }
         </div>
     );
 }

--- a/src/Widgets/CloseOrClear.js
+++ b/src/Widgets/CloseOrClear.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import { useRef } from 'react';
 
 import './LabeledInput.scss';
 

--- a/src/Widgets/LabeledSelect.js
+++ b/src/Widgets/LabeledSelect.js
@@ -6,7 +6,6 @@ import './LabeledInput.scss';
 // This is generally not considered a Good Idea, but this
 // particular component is small and has no utility outside this module.
 function LabeledSelectOption(props) {
-    const isSelected = props.value === props.currentValue;
     return <option value={props.value}>{props.label}</option>
 }
 

--- a/src/Widgets/LoginStatus.js
+++ b/src/Widgets/LoginStatus.js
@@ -3,23 +3,27 @@ import { useContext } from 'react';
 import './LoginStatus.scss';
 
 import BombayLoginContext from '../Context/BombayLoginContext';
-import BombayUtilityContext from '../Context/BombayUtilityContext';
 
 import { logout } from "../Network/Login";
 import Button from './Button';
 
 function LoginStatus(props) {
-    const loggedIn = useContext(BombayLoginContext);
-    const { setLoginState } = useContext(BombayUtilityContext);
+    const { loggedIn, setLoggedIn, setShowLogin }= useContext(BombayLoginContext);
 
     async function doLogout() {
         await logout();
-        setLoginState(false);
+        setLoggedIn(false);
+    }
+
+    function showLogin() {
+        setShowLogin(true);
     }
 
     return (
         <div className="login-status">
-            {loggedIn ? <Button className="logout btn" onClick={doLogout} disabled={false} label='Logout' /> : <div className="label">Please Login</div>}
+            {loggedIn ?
+                <Button className="logout btn" onClick={doLogout} disabled={false} label='Logout' /> :
+                <Button className="login btn" onClick={showLogin} disabled={false} label="Login" />}
         </div>
     );
 }

--- a/src/Widgets/LoginStatus.test.js
+++ b/src/Widgets/LoginStatus.test.js
@@ -1,86 +1,85 @@
 import * as NetworkLogin from '../Network/Login';
 jest.mock('../Network/Login');
 
-import { useState } from 'react';
-import { BrowserRouter } from 'react-router-dom';
 
 import { act, render, screen } from '@testing-library/react';
 
-const testToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJGREM4MTEzOCIsInVzZXIiOnsiaWQiOjEsIm5hbWUiOiJhZG1pbiIsImFkbWluIjpmYWxzZX0sImlhdCI6MTY2NTk2NTA5OX0.2vz14X7Tm-oFlyOa7dcAF-5y5ympi_UlWyJNxO4xyS4';
-
-import BombayLoginContext from '../Context/BombayLoginContext';
-import BombayUtilityContext from '../Context/BombayUtilityContext';
-
 import LoginStatus from './LoginStatus';
-
-let mockLoggedIn = false;
-
-function FakeContent(props) {
-    const [loginState, setLoginState] = useState(mockLoggedIn);
-
-    const setMode = async newMode => {
-        setModeState(newMode);
-    }
-
-    const utilities = {
-        setMode,
-        setLoginState,
-    }
-
-    return (
-        <BrowserRouter basename="/">
-            <BombayLoginContext.Provider value={loginState}>
-                <BombayUtilityContext.Provider value={utilities}>
-                    {props.children}
-                </BombayUtilityContext.Provider>
-            </BombayLoginContext.Provider>
-        </BrowserRouter>
-    );
-}
 
 beforeEach(() => {
     localStorage.removeItem('jwttoken');
-    mockLoggedIn = false;
 })
 
 afterEach(() => {
     localStorage.removeItem('jwttoken');
-    mockLoggedIn = false;
 })
 
-it('should render the login status (logged out)', async () => {
+it('should show the login button when logged out', async () => {
     const { asFragment } = render(
-        <FakeContent>
+        <ContextChanger loggedIn={false}>
             <LoginStatus />
-        </FakeContent>
+        </ContextChanger>
     )
 
     expect(asFragment).toMatchSnapshot();
-    const statusDiv = screen.getByText('Please Login');
-    expect(statusDiv).toBeVisible();
+
+    const loginForm = screen.queryByText('Showing Log In Form');
+    expect(loginForm).toBeNull()
+
+    const loginButton = screen.getByText('Login');
+    expect(loginButton).toBeVisible();
+    expect(loginButton.tagName).toBe('BUTTON');
 });
 
-it('should show the logout button when logged in', async () => {
-    mockLoggedIn = true;
-    const { asFragment } = render(
-        <FakeContent>
+it('should show the login form when the login button is pressed', async () => {
+    render(
+        <ContextChanger loggedIn={false}>
             <LoginStatus />
-        </FakeContent>
+        </ContextChanger>
+    )
+
+    let loginForm = screen.queryByText('Showing Log In Form');
+    expect(loginForm).toBeNull()
+
+    const loginButton = screen.getByText('Login');
+
+    await act(async () => {
+        loginButton.click();
+    })
+
+    loginForm = screen.queryByText('Showing Log In Form');
+    expect(loginForm).not.toBeNull();
+    expect(loginForm).toBeInTheDocument();
+})
+
+it('should show the logout button when logged in', async () => {
+    const { asFragment } = render(
+        <ContextChanger loggedIn={true}>
+            <LoginStatus />
+        </ContextChanger>
     )
     expect(asFragment).toMatchSnapshot();
+
+    const loginForm = screen.queryByText('Showing Log In Form');
+    expect(loginForm).toBeNull()
+
     const logoutButton = screen.getByText('Logout');
     expect(logoutButton).toBeVisible();
+    expect(logoutButton.tagName).toBe('BUTTON');
 });
 
 it('should logout when the logout button is pressed', async () => {
     const { resolve } = NetworkLogin._setupMocks();
 
-    mockLoggedIn = true;
     const result = render(
-        <FakeContent>
+        <ContextChanger loggedIn={true}>
             <LoginStatus />
-        </FakeContent>
+        </ContextChanger>
     )
+
+
+    let loginForm = screen.queryByText('Showing Log In Form');
+    expect(loginForm).toBeNull()
 
     const logoutButton = screen.getByText('Logout');
 
@@ -90,4 +89,8 @@ it('should logout when the logout button is pressed', async () => {
     });
 
     expect(NetworkLogin.logout).toBeCalledTimes(1);
+
+    loginForm = screen.queryByText('Showing Log In Form');
+    expect(loginForm).toBeNull()
+
 });

--- a/src/Widgets/__snapshots__/LoginStatus.test.js.snap
+++ b/src/Widgets/__snapshots__/LoginStatus.test.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render the login status (logged out) 1`] = `[Function]`;
+exports[`should show the login button when logged out 1`] = `[Function]`;
 
 exports[`should show the logout button when logged in 1`] = `[Function]`;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -35,22 +35,35 @@ globalThis.makeResolvablePromise = function () {
 
 // Use this to turn the crank on context changes.
 globalThis.ContextChanger = function (props) {
-    const [loginState, setLoginState] = useState(props.loginState);
-    const [modeState, setModeState] = useState(props.modeState);
+    const [loginState, setLoginState] = useState(props.loggedIn);
+    const [showLoginForm, setShowLoginForm] = useState(props.showLoginForm);
 
-    function toggleLogin() {
-        setLoginState(!loginState);
+    const loginContext = {
+        loggedIn: loginState,
+        showLoginForm: showLoginForm,
+        setLoggedIn: newLoggedIn => {
+            if (newLoggedIn) {
+                setShowLoginForm(false);
+            }
+
+            setLoginState(newLoggedIn);
+        },
+
+        setShowLogin: newShow => {
+            if (loginState) return;
+            setShowLoginForm(newShow);
+        },
     }
 
-    function updateModeState(evt) {
-        setModeState(evt.currentTarget.value);
+    function toggleLogin() {
+        loginContext.setLoggedIn(!loginState);
     }
 
     return (
-        <BombayLoginContext.Provider value={loginState}>
+        <BombayLoginContext.Provider value={loginContext}>
             {props.children}
+            {showLoginForm ? <div>Showing Log In Form</div> : null}
             <button className="change-test-login" onClick={toggleLogin}>Change Login</button>
-            <input className="change-test-mode" type='text' onChange={updateModeState} />
         </BombayLoginContext.Provider>
     );
 }


### PR DESCRIPTION
- Conditional route rendering.
- Changing the way logged in status is tracked.
- Adding a showLoginForm status.
- useLoginTracking, App, and LoginStatus tests are fixed.
- LoginStatus shows login button when logged out.
- Clicking the login button sets showLoginForm to true.
- The Login form respects showLoginForm
- Content Routes render top on logout for valid routes
- Top changes for logged in and logged out