### PR TITLE
Move collection model handling to a new custom hook.

### DIFF
--- a/src/Hooks/useModelCollection.js
+++ b/src/Hooks/useModelCollection.js
@@ -1,0 +1,89 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+import useIntersectionObserver from './useIntersectionObserver';
+
+function useModelCollection({ CollectionClass, topRef, loginState }) {
+    const { loggedIn } = loginState;
+
+    const collection = useRef(null);
+    const observer = useIntersectionObserver(topRef, (entries, observer) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                setShouldPage(true);
+                observer.unobserve(entry.target);
+            }
+
+            // I haven't found a case where this is actually needed, but I haven't ruled it out.
+            // if (entry.isVisible) {
+            // }
+        });
+    });
+
+    const [shouldPage, setShouldPage] = useState(false);
+    const [loading, setLoading] = useState(true);
+
+    const refreshCollection = useCallback(() => {
+        // console.count('refresh');
+        if (!loggedIn) {
+            collection.current = null;
+            return;
+        }
+
+        setLoading(true);
+
+        collection.current = new CollectionClass();
+        collection.current.ready()
+        .then(() => {
+            setLoading(false);
+        });
+    }, [loggedIn, CollectionClass]);
+
+    useEffect(() => {
+        // console.count('refresh changed');
+        if (collection.current == null) {
+            refreshCollection()
+        }
+    }, [refreshCollection]);
+
+    useEffect(() => {
+        // console.count(`shouldPage: ${shouldPage}, loading: ${loading}`);
+        if (!shouldPage) { return; }
+        if (loading) { return; }
+
+        setShouldPage(false);
+
+        if (collection.current.hasNextPage()) {
+            setLoading(true);
+
+            collection.current.fetchNextPage()
+            .then(() => {
+                setLoading(false);
+            });
+        }
+    }, [shouldPage, loading]);
+
+    useEffect(() => {
+        // console.count(`loading: ${loading}, observer: ${observer}, topRef: ${topRef}`);
+        if (loading) { return; }
+
+        if (collection.current && collection.current.hasNextPage()) {
+            const myElement = topRef.current?.querySelector('li:last-child');
+
+            if (myElement) {
+                observer.current.observe(myElement);
+            }
+        }
+    }, [loading, observer, topRef]);
+
+    useEffect(() => {
+        // console.count(`loggedIn: ${loggedIn}`);
+        if (loggedIn && collection.current === null) {
+            refreshCollection()
+        }
+    }, [loggedIn, refreshCollection]);
+
+    // console.log('return collection', collection);
+    return [collection, refreshCollection];
+}
+
+export default useModelCollection

--- a/src/Hooks/useModelCollection.test.js
+++ b/src/Hooks/useModelCollection.test.js
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from 'react';
+import { act, render } from '@testing-library/react';
+
+// The order of these mocks matters.  Login *must* come before network.
+import * as NetworkLogin from '../Network/Login';
+jest.mock('../Network/Login');
+
+import * as Network from '../Network/Network';
+jest.mock('../Network/Network');
+
+import useIntersectionObserver, * as mockObserver from './useIntersectionObserver';
+jest.mock('./useIntersectionObserver');
+
+import jwt_decode from 'jwt-decode';
+jest.mock('jwt-decode');
+
+import ModelBase from '../Model/ModelBase';
+import CollectionBase from '../Model/CollectionBase';
+
+class TestModel extends ModelBase {};
+class TestCollection extends CollectionBase {
+    constructor(options = {}) {
+        super('/testTable', { ...options, modelClass: TestModel });
+    }
+};
+
+import useModelCollection from './useModelCollection';
+
+let testRef;
+let testCollection;
+let testSetLoggedIn;
+
+function TestApp({ loggedIn, showLoginForm }) {
+    const [loginState, setLoginState] = useState({ loggedIn, showLoginForm });
+
+    testSetLoggedIn = (isLoggedIn) => {
+        setLoginState(oldState => { return {...oldState, loggedIn: isLoggedIn}; });
+    }
+
+    const topRef = useRef();
+    const [collection] = useModelCollection({
+        CollectionClass: TestCollection,
+        topRef,
+        loginState,
+    });
+
+    useEffect(() => {
+        testRef = topRef;
+    }, [topRef]);
+
+    useEffect(() => {
+        testCollection = collection;
+    }, [collection]);
+
+    return (
+        <div ref={topRef}>
+            {collection?.current == null ? '' : collection.current.map(model => {
+                const key = `collection-${model.get('id')}`;
+                return <div key={key} model={model}>model.get('name')</div>
+            })}
+        </div>
+    )
+}
+
+jest.useFakeTimers();
+
+function setupLogin(loggedIn = true, token = 'xyzzy') {
+    const loginPromise = NetworkLogin._setupMocks();
+    loginPromise.resolve({ loggedIn, token });
+}
+
+afterEach(() => {
+    while (mockObserver.mockObserver.observers.length > 0) {
+        mockObserver.mockObserver.observers.pop();
+    }
+});
+
+it('should get the collection and start loading', async () => {
+    setupLogin();
+    const { resolve } = Network._setupMocks();
+    render(<TestApp loggedIn={true} showLoginForm={false} />);
+
+    const [fetchBody, models] = makeModels(10, {}, 'testTable');
+
+    await act(async () => {
+        resolve(fetchBody);
+    });
+
+    expect(mockObserver.mockObserver.observers.length).toBe(1);
+    expect(testCollection.current.models()).toEqual(models);
+})
+
+it('should get the next page', async () => {
+    setupLogin();
+    let networkPromise = Network._setupMocks();
+    render(<TestApp loggedIn={true} showLoginForm={false} />);
+
+    const fetchBody = [];
+    const models = [];
+
+    [fetchBody[0], models[0]] = makeModels(10, {}, 'testTable');
+
+    await act(async () => {
+        networkPromise.resolve(fetchBody[0]);
+    });
+
+    expect(mockObserver.mockObserver.observers.length).toBe(1);
+    expect(testCollection.current.models()).toEqual(models[0]);
+
+    networkPromise = Network._setupMockPromise();
+    [fetchBody[1], models[1]] = makeModels(10, {offset: 10, limit: 10}, 'testTable');
+
+    const observer = mockObserver.mockObserver.observers[0];
+
+    await act(async () => {
+        observer._fireIntersect(testRef.current.lastChild);
+        networkPromise.resolve(fetchBody[1]);
+    });
+
+    expect(testCollection.current.models()).toEqual([...models[0], ...models[1]]);
+})
+
+it('should stop when it runs out of data', async () => {
+    setupLogin();
+    let networkPromise = Network._setupMocks();
+    render(<TestApp loggedIn={true} showLoginForm={false} />);
+
+    const fetchBody = [];
+    const models = [];
+
+    [fetchBody[0], models[0]] = makeModels(10, {}, 'testTable');
+
+    await act(async () => {
+        networkPromise.resolve(fetchBody[0]);
+    });
+
+    expect(mockObserver.mockObserver.observers.length).toBe(1);
+    expect(testCollection.current.models()).toEqual(models[0]);
+
+    networkPromise = Network._setupMockPromise();
+
+    const observer = mockObserver.mockObserver.observers[0];
+
+    await act(async () => {
+        observer._fireIntersect(testRef.current.lastChild);
+        networkPromise.reject({ status: 404, message: 'Not Found' });
+    });
+
+    expect(testCollection.current.models()).toEqual(models[0]);
+});
+
+it('should return a null collection when not logged in', async () => {
+    render(<TestApp loggedIn={false} showLoginForm={false} />);
+
+    expect(mockObserver.mockObserver.observers.length).toBe(1);
+    expect(testCollection.current).toBeNull();
+});
+
+it('should load the collection on login', async () => {
+    setupLogin();
+    render(<TestApp loggedIn={false} showLoginForm={false} />);
+
+    expect(mockObserver.mockObserver.observers.length).toBe(1);
+    expect(testCollection.current).toBeNull();
+
+    const { resolve } = Network._setupMocks();
+
+    await act(async () => {
+        testSetLoggedIn(true);
+    });
+
+    const [fetchBody, models] = makeModels(10, {}, 'testTable');
+
+    await act(async () => {
+        resolve(fetchBody);
+    });
+
+    expect(mockObserver.mockObserver.observers.length).toBe(1);
+    expect(testCollection.current.models()).toEqual(models);
+});

--- a/src/Mode/Artist/ArtistList.js
+++ b/src/Mode/Artist/ArtistList.js
@@ -1,5 +1,4 @@
-import { useEffect, useState, useRef, useContext, createRef, useCallback } from 'react';
-import useIntersectionObserver from '../../Hooks/useIntersectionObserver';
+import { useState, useContext, createRef } from 'react';
 
 import './ArtistList.scss';
 
@@ -10,91 +9,26 @@ import ArtistCollection from '../../Model/ArtistCollection';
 import ArtistListItem from './ArtistListItem';
 import Artist from './Artist';
 import FormModal from '../../Modal/FormModal';
+import useModelCollection from '../../Hooks/useModelCollection';
 
 function ArtistList(props) {
     const topRef = createRef();
 
-    const { loggedIn } = useContext(BombayLoginContext);
+    const loginState = useContext(BombayLoginContext);
 
-    const artistCollection = useRef(null);
-    const observer = useIntersectionObserver(topRef, (entries, observer) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                setShouldPage(true);
-                observer.unobserve(entry.target);
-            }
-
-            // I haven't found a case where this is actually needed, but I haven't ruled it out.
-            // if (entry.isVisible) {
-            // }
-        });
+    const [artistCollection, refreshCollection] = useModelCollection({
+        CollectionClass: ArtistCollection,
+        topRef, loginState,
     });
 
     const [showAdd, setShowAdd] = useState(false);
-    const [shouldPage, setShouldPage] = useState(false);
-    const [loading, setLoading] = useState(true);
-
-    const refreshCollection = useCallback(() => {
-        if (!loggedIn) {
-            artistCollection.current = null;
-            return;
-        }
-
-        setLoading(true);
-
-        artistCollection.current = new ArtistCollection();
-        artistCollection.current.ready()
-            .then(() => {
-                setLoading(false);
-            });
-    }, [loggedIn]);
-
-    useEffect(() => {
-        if (artistCollection.current == null) {
-            refreshCollection()
-        }
-    }, [refreshCollection]);
-
-    useEffect(() => {
-        if (!shouldPage) { return; }
-        if (loading) { return; }
-
-        setShouldPage(false);
-
-        if (artistCollection.current.hasNextPage()) {
-            setLoading(true);
-
-            artistCollection.current.fetchNextPage()
-                .then(() => {
-                    setLoading(false);
-                });
-        }
-    }, [shouldPage, loading]);
-
-    useEffect(() => {
-        if (loading) { return; }
-
-        if (artistCollection.current && artistCollection.current.hasNextPage()) {
-            const myElement = topRef.current.querySelector('li:last-child');
-
-            if (myElement) {
-                observer.current.observe(myElement);
-            }
-        }
-    }, [loading, observer, topRef]);
-
-    useEffect(() => {
-        if (loggedIn && artistCollection.current === null) {
-            refreshCollection()
-        }
-    }, [loggedIn, refreshCollection]);
 
     async function submitNewArtist(artistDef) {
         await artistCollection.current.save(artistDef);
         refreshCollection();
     }
 
-    if (!loggedIn) return null;
+    if (!loginState.loggedIn) return null;
 
     return (
         <div className="list-component">

--- a/src/Mode/Song/SongList.js
+++ b/src/Mode/Song/SongList.js
@@ -1,5 +1,4 @@
-import { useEffect, useState, useRef, useContext, createRef, useCallback } from 'react';
-import useIntersectionObserver from '../../Hooks/useIntersectionObserver';
+import { useState, useContext, createRef } from 'react';
 
 import './SongList.scss';
 
@@ -10,91 +9,26 @@ import SongCollection from '../../Model/SongCollection';
 import SongListItem from './SongListItem';
 import Song from './Song';
 import FormModal from '../../Modal/FormModal';
+import useModelCollection from '../../Hooks/useModelCollection';
 
 function SongList(props) {
     const topRef = createRef();
 
-    const { loggedIn } = useContext(BombayLoginContext);
+    const loginState = useContext(BombayLoginContext);
 
-    const songCollection = useRef(null);
-    const observer = useIntersectionObserver(topRef, (entries, observer) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                setShouldPage(true);
-                observer.unobserve(entry.target);
-            }
-
-            // I haven't found a case where this is actually needed, but I haven't ruled it out.
-            // if (entry.isVisible) {
-            // }
-        });
+    const [songCollection, refreshCollection] = useModelCollection({
+        CollectionClass: SongCollection,
+        topRef, loginState,
     });
 
     const [showAdd, setShowAdd] = useState(false);
-    const [shouldPage, setShouldPage] = useState(false);
-    const [loading, setLoading] = useState(true);
-
-    const refreshCollection = useCallback(() => {
-        if (!loggedIn) {
-            songCollection.current = null;
-            return;
-        }
-
-        setLoading(true);
-
-        songCollection.current = new SongCollection();
-        songCollection.current.ready()
-            .then(() => {
-                setLoading(false);
-            });
-    }, [loggedIn]);
-
-    useEffect(() => {
-        if (songCollection.current == null) {
-            refreshCollection();
-        }
-    }, [refreshCollection]);
-
-    useEffect(() => {
-        if (!shouldPage) { return; }
-        if (loading) { return; }
-
-        setShouldPage(false);
-
-        if (songCollection.current.hasNextPage()) {
-            setLoading(true);
-
-            songCollection.current.fetchNextPage()
-                .then(() => {
-                    setLoading(false);
-                });
-        }
-    }, [shouldPage, loading]);
-
-    useEffect(() => {
-        if (loading) { return; }
-
-        if (songCollection.current && songCollection.current.hasNextPage()) {
-            const myElement = topRef.current.querySelector('li:last-child');
-
-            if (myElement) {
-                observer.current.observe(myElement);
-            }
-        }
-    }, [loading, observer, topRef]);
-
-    useEffect(() => {
-        if (loggedIn && songCollection.current === null) {
-            refreshCollection()
-        }
-    }, [loggedIn, refreshCollection]);
 
     async function submitNewSong(songDef) {
         await songCollection.current.save(songDef);
         refreshCollection();
     }
 
-    if (!loggedIn) return null;
+    if (!loginState.loggedIn) return null;
 
     return (
         <div className="list-component">

--- a/src/Widgets/PickerButton.test.js
+++ b/src/Widgets/PickerButton.test.js
@@ -1,10 +1,16 @@
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import { useState } from 'react';
 
 import * as Network from '../Network/Network';
-import * as mockObserver from '../Hooks/useIntersectionObserver';
-
-import * as Login from '../Network/Login';
 jest.mock('../Network/Login');
+
+import * as mockObserver from '../Hooks/useIntersectionObserver';
+jest.mock('../Hooks/useIntersectionObserver');
+
+import * as NetworkLogin from '../Network/Login';
+jest.mock('../Network/Login');
+
+import BombayLoginContext from '../Context/BombayLoginContext';
 
 import ModelBase from '../model/ModelBase';
 import CollectionBase from '../model/CollectionBase';
@@ -19,9 +25,30 @@ class TestCollection extends CollectionBase {
 
 import PickerButton from './PickerButton';
 
+let testSetLoggedIn;
+
+function TestWrapper({ loggedIn, showLoginForm, children }) {
+    const [loginState, setLoginState] = useState({ loggedIn, showLoginForm });
+
+    testSetLoggedIn = (isLoggedIn) => {
+        setLoginState(oldState => { return { ...oldState, loggedIn: isLoggedIn }; });
+    }
+
+    return (
+        <BombayLoginContext.Provider value={loginState}>
+            {children}
+        </BombayLoginContext.Provider>
+    )
+}
+
 jest.useFakeTimers();
 
 const testToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJGREM4MTEzOCIsInVzZXIiOnsiaWQiOjEsIm5hbWUiOiJhZG1pbiIsImFkbWluIjpmYWxzZX0sImlhdCI6MTY2NTk2NTA5OX0.2vz14X7Tm-oFlyOa7dcAF-5y5ympi_UlWyJNxO4xyS4';
+
+function setupLogin(loggedIn = true, token = testToken) {
+    const loginPromise = NetworkLogin._setupMocks();
+    loginPromise.resolve({ loggedIn, token });
+}
 
 beforeEach(() => {
     localStorage.setItem('jwttoken', testToken);
@@ -36,50 +63,58 @@ afterEach(() => {
 })
 
 it('should show the button', async () => {
-    const loginPromise = Login._setupMocks();
-    loginPromise.resolve({
-        loggedIn: true,
-        token: testToken,
-    });
+    setupLogin();
 
     const onModelPicked = jest.fn();
 
-    const { asFragment } = render(
-        <PickerButton
-            collectionClass={TestCollection}
-            modelName='table1'
-            fieldName='id'
-            targetField='table2_id'
-            labelText='Pick A Model'
-            onModelPicked={onModelPicked}
-        />
+    const { resolve } = Network._setupMocks();
+
+    const { asFragment, container } = render(
+        <TestWrapper loggedIn={true} showLoginForm={false}>
+            <PickerButton
+                collectionClass={TestCollection}
+                modelName='table1'
+                fieldName='id'
+                targetField='table2_id'
+                labelText='Pick A Model'
+                onModelPicked={onModelPicked}
+            />
+        </TestWrapper>
     );
 
     expect(asFragment).toMatchSnapshot();
 
     expect(mockObserver.mockObserver.observers.length).toBe(0);
+    const [fetchBody] = makeModels(10, {});
+
+    await act(async () => {
+        resolve(fetchBody);
+    })
+
+    expect(mockObserver.mockObserver.observers.length).toBe(0);
+    const listComponent = container.querySelector('.picker-component');
+    expect(listComponent).toBeNull();
 })
 
 it('should show the list on click', async () => {
-    const loginPromise = Login._setupMocks();
-    loginPromise.resolve({
-        loggedIn: true,
-        token: testToken,
-    });
+
+    setupLogin();
 
     const onModelPicked = jest.fn();
 
     const { resolve } = Network._setupMocks();
 
     const { container, queryByText } = render(
-        <PickerButton
-            collectionClass={TestCollection}
-            modelName='table1'
-            fieldName='id'
-            targetField='table2_id'
-            labelText='Pick A Model'
-            onModelPicked={onModelPicked}
-        />
+        <TestWrapper loggedIn={true} showLoginForm={false}>
+            <PickerButton
+                collectionClass={TestCollection}
+                modelName='table1'
+                fieldName='id'
+                targetField='table2_id'
+                labelText='Pick A Model'
+                onModelPicked={onModelPicked}
+            />
+        </TestWrapper>
     );
 
     let listComponent = container.querySelector('.picker-component');
@@ -100,25 +135,23 @@ it('should show the list on click', async () => {
 })
 
 it('should call the callback and close the list when an item is clicked', async () => {
-    const loginPromise = Login._setupMocks();
-    loginPromise.resolve({
-        loggedIn: true,
-        token: testToken,
-    });
+    setupLogin();
 
     const onModelPicked = jest.fn();
 
     const { resolve } = Network._setupMocks();
 
     const { container, queryByText } = render(
-        <PickerButton
-            collectionClass={TestCollection}
-            modelName='table1'
-            fieldName='id'
-            targetField='table2_id'
-            labelText='Pick A Model'
-            onModelPicked={onModelPicked}
-        />
+        <TestWrapper loggedIn={true} showLoginForm={false}>
+            <PickerButton
+                collectionClass={TestCollection}
+                modelName='table1'
+                fieldName='id'
+                targetField='table2_id'
+                labelText='Pick A Model'
+                onModelPicked={onModelPicked}
+            />
+        </TestWrapper>
     );
 
     const showButton = queryByText(/Please Choose/);
@@ -147,11 +180,7 @@ it('should call the callback and close the list when an item is clicked', async 
 })
 
 it('should close the list without calling if the button is pushed again', async () => {
-    const loginPromise = Login._setupMocks();
-    loginPromise.resolve({
-        loggedIn: true,
-        token: testToken,
-    });
+    setupLogin();
 
     const onModelPicked = jest.fn();
 

--- a/src/Widgets/PickerList.js
+++ b/src/Widgets/PickerList.js
@@ -1,80 +1,25 @@
-import { useEffect, useState, useRef, createRef, useCallback } from 'react';
+import { createRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 
-import useIntersectionObserver from '../Hooks/useIntersectionObserver';
+import BombayLoginContext from '../Context/BombayLoginContext';
+import useModelCollection from '../Hooks/useModelCollection';
 
-function PickerList(props) {
+function PickerList({ pickModel, isOpen, collectionClass }) {
     const topRef = createRef();
 
-    const listCollection = useRef(null);
-    const observer = useIntersectionObserver(topRef, (entries, observer) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                setShouldPage(true);
-                observer.unobserve(entry.target);
-            }
+    const loginState = useContext(BombayLoginContext);
 
-            // I haven't found a case where this is actually needed, but I haven't ruled it out.
-            // if (entry.isVisible) {
-            // }
-        });
+    const [listCollection] = useModelCollection({
+        CollectionClass: collectionClass,
+        topRef, loginState,
     });
-
-    const [shouldPage, setShouldPage] = useState(false);
-    const [loading, setLoading] = useState(true);
-
-    const refreshCollection = useCallback(() => {
-        setLoading(true);
-
-        listCollection.current = new props.collectionClass();
-        listCollection.current.ready()
-            .then(() => {
-                setLoading(false);
-            });
-    }, [props.collectionClass]);
-
-    useEffect(() => {
-        if (!props.isOpen) return;
-
-        if (listCollection.current == null) {
-            refreshCollection()
-        }    
-    }, [props.isOpen, refreshCollection]);    
-
-    useEffect(() => {
-        if (!shouldPage) return;
-        if (loading) return;
-
-        setShouldPage(false);
-
-        if (listCollection.current.hasNextPage()) {
-            setLoading(true);
-
-            listCollection.current.fetchNextPage()
-                .then(() => {
-                    setLoading(false);
-                });    
-        }        
-    }, [shouldPage, loading]);    
-
-    useEffect(() => {
-        if (loading) return;
-
-        if (listCollection.current && listCollection.current.hasNextPage()) {
-            const myElement = topRef.current?.querySelector('li:last-child');
-
-            if (myElement) {
-                observer.current.observe(myElement);
-            }    
-        }    
-    }, [loading, observer, topRef]);    
 
     function clickHandler(evt, model ) {
         evt.preventDefault();
-        props.pickModel(model);
+        pickModel(model);
     }
 
-    if (!props.isOpen) return null;
+    if (!isOpen) return null;
 
     return (
         <div className="picker-component">

--- a/src/Widgets/PickerList.test.js
+++ b/src/Widgets/PickerList.test.js
@@ -1,27 +1,54 @@
-import { act, render } from '@testing-library/react';
+import { useState } from 'react';
+
+import { act, render, screen } from '@testing-library/react';
+
+import * as NetworkLogin from '../Network/Login';
+jest.mock('../Network/Login');
 
 import * as Network from '../Network/Network';
-import  * as mockObserver from '../Hooks/useIntersectionObserver';
+jest.mock('../Network/Network');
 
-import * as Login from '../Network/Login';
-jest.mock('../Network/Login');
+import * as mockObserver from '../Hooks/useIntersectionObserver';
+jest.mock('../Hooks/useIntersectionObserver');
+
+import BombayLoginContext from '../Context/BombayLoginContext';
 
 import ModelBase from '../model/ModelBase';
 import CollectionBase from '../model/CollectionBase';
 
-class TestModel extends ModelBase{};
+class TestModel extends ModelBase { };
 
 class TestCollection extends CollectionBase {
-    constructor(options={}) {
-        super('/table1', {...options, modelClass: TestModel});
+    constructor(options = {}) {
+        super('/table1', { ...options, modelClass: TestModel });
     }
 }
 
 import PickerList from './PickerList';
 
+function TestWrapper({ loggedIn, showLoginForm, children }) {
+    debugger;
+    const [loginState, setLoginState] = useState({ loggedIn, showLoginForm });
+
+    testSetLoggedIn = (isLoggedIn) => {
+        setLoginState(oldState => { return { ...oldState, loggedIn: isLoggedIn }; });
+    }
+
+    return (
+        <BombayLoginContext.Provider value={loginState}>
+            {children}
+        </BombayLoginContext.Provider>
+    )
+}
+
 jest.useFakeTimers();
 
 const testToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJGREM4MTEzOCIsInVzZXIiOnsiaWQiOjEsIm5hbWUiOiJhZG1pbiIsImFkbWluIjpmYWxzZX0sImlhdCI6MTY2NTk2NTA5OX0.2vz14X7Tm-oFlyOa7dcAF-5y5ympi_UlWyJNxO4xyS4';
+
+function setupLogin(loggedIn = true, token = testToken) {
+    const loginPromise = NetworkLogin._setupMocks();
+    loginPromise.resolve({ loggedIn, token });
+}
 
 beforeEach(() => {
     localStorage.setItem('jwttoken', testToken);
@@ -36,25 +63,22 @@ afterEach(() => {
 })
 
 it('should show the list', async () => {
-    const loginPromise = Login._setupMocks();
-    loginPromise.resolve({
-        loggedIn: true,
-        token: testToken,
-    });
-
+    setupLogin();
     const pickModel = jest.fn();
 
     const { resolve } = Network._setupMocks();
 
-    const  { asFragment } = render(
-        <PickerList
-            pickModel={pickModel}
-            isOpen={true}
-            collectionClass={TestCollection}
-        />
+    const { asFragment } = render(
+        <TestWrapper loggedIn={true} showLoginForm={false}>
+            <PickerList
+                pickModel={pickModel}
+                isOpen={true}
+                collectionClass={TestCollection}
+            />
+        </TestWrapper>
     );
 
-    const [fetchBody] = makeModels(10, {});
+    const [fetchBody, models] = makeModels(10, {});
 
     await act(async () => {
         resolve(fetchBody);
@@ -69,106 +93,8 @@ it('should show the list', async () => {
 
     const listElements = asFragment().querySelectorAll('li.picker-item');
     expect(listElements).toHaveLength(10);
-});
 
-it('should be an empty component', async () => {
-    const loginPromise = Login._setupMocks();
-    loginPromise.resolve({
-        loggedIn: true,
-        token: testToken,
-    });
-
-    const pickModel = jest.fn();
-
-    const { container } = render(
-        <PickerList
-            pickModel={pickModel}
-            isOpen={false}
-            collectionClass={TestCollection}
-        />
-    );
-
-    expect(container).toBeEmptyDOMElement()
-});
-
-it('should show the next page', async () => {
-    const loginPromise = Login._setupMocks();
-    loginPromise.resolve({
-        loggedIn: true,
-        token: testToken,
-    });
-
-    const pickModel = jest.fn();
-
-    const { resolve } = Network._setupMocks();
-
-    const { asFragment } = render(
-        <PickerList
-            pickModel={pickModel}
-            isOpen={true}
-            collectionClass={TestCollection}
-        />
-    );
-
-    const [fetchBody] = makeModels(10, {});
-
-    await act(async () => {
-        resolve(fetchBody);
-    });
-
-    expect(mockObserver.mockObserver.observers.length).toBe(1);
-    expect(Network.getFromURLString).toBeCalledTimes(1);
-    expect(Network.getFromURLString).toBeCalledWith('http://localhost:2001/xyzzy/table1');
-    expect(Network.getFromURLString.mock.results[0].value).resolves.toEqual(fetchBody);
-
-    const { resolve: resolve2, reject, promise } = Network._setupMockPromise();
-
-    const [fetchBody2] = makeModels(10, {offset: 10, limit: 10});
-    const lastItem = asFragment().querySelector('li.picker-item:last-child');
-    const observer = mockObserver.mockObserver.observers[0];
-
-    await act(async () => {
-        observer._fireIntersect(lastItem);
-        resolve2(fetchBody2);
-    });
-
-    expect(mockObserver.mockObserver.observers.length).toBe(1);
-    expect(Network.getFromURLString).toBeCalledTimes(2);
-    expect(Network.getFromURLString).toHaveBeenLastCalledWith('http://localhost:2001/xyzzy/table1?offset=10&limit=10');
-    expect(Network.getFromURLString.mock.results[1].value).resolves.toEqual(fetchBody2);
-
-    const listElements = asFragment().querySelectorAll('li.picker-item');
-    expect(listElements).toHaveLength(20);
-});
-
-it('should call the callback when an item is clicked', async () => {
-    const loginPromise = Login._setupMocks();
-    loginPromise.resolve({
-        loggedIn: true,
-        token: testToken,
-    });
-
-    const pickModel = jest.fn();
-
-    const { resolve } = Network._setupMocks();
-
-    const { container, queryByText } = render(
-        <PickerList
-            pickModel={pickModel}
-            isOpen={true}
-            collectionClass={TestCollection}
-        />
-    );
-
-    const [fetchBody, models] = makeModels(10, {});
-
-    await act(async () => {
-        resolve(fetchBody);
-    });
-
-    expect(pickModel).not.toBeCalled();
-
-    const el = queryByText(models[1].get('name'));
+    const el = screen.queryByText(models[1].get('name'));
     el.click();
 
     expect(pickModel).toBeCalled();


### PR DESCRIPTION
useModelCollection handles all the logic for managing reading collections, handling paging, and responding to changes in login status.

ArtistList, SongList, and PickerList now use useModelCollection.